### PR TITLE
Simplify types

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,6 +5,7 @@
     "prettier/@typescript-eslint"
   ],
   "rules": {
+    "@typescript-eslint/no-explicit-any": false,
     "@typescript-eslint/no-use-before-define": false,
     "@typescript-eslint/no-parameter-properties": false,
     "@typescript-eslint/explicit-function-return-type": false

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.2.0",
   "description": "three way merge JSON and arbitrary structures",
   "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
+  "module": "./dist/index.esm.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
     "test": "jest --watch",

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export {
   trimergeEquality,
   trimergeEqualityCreator,
   CannotMergeError,
+  MergeFn,
 } from './trimerge';
 export {
   trimergeArrayCreator,

--- a/src/trimerge-json.test.ts
+++ b/src/trimerge-json.test.ts
@@ -1,7 +1,7 @@
 import {
-  AnyMerge,
-  combineMergers,
   CannotMergeError,
+  combineMergers,
+  MergeFn,
   trimergeEquality,
 } from './trimerge';
 import { Path } from './path';
@@ -38,8 +38,8 @@ describe('trimergeJsonDeepEqual', () => {
   });
 });
 
-function mockPathTrackingMerger(paths: Path[]): AnyMerge {
-  return (_orig, _left, _right, path): typeof CannotMerge => {
+function mockPathTrackingMerger(paths: Path[]): MergeFn {
+  return (_orig, _left, _right, path = []): typeof CannotMerge => {
     paths.push(path);
     return CannotMerge;
   };

--- a/src/trimerge-json.ts
+++ b/src/trimerge-json.ts
@@ -4,7 +4,7 @@ import { diff3MergeIndices, Index } from 'node-diff3';
 import { CannotMerge } from './cannot-merge';
 import deepEqual from './json-equal';
 import { type } from './type';
-import { AnyMerge, MergeFn, trimergeEqualityCreator } from './trimerge';
+import { MergeFn, trimergeEqualityCreator } from './trimerge';
 
 type ArrayKeyFn = (item: any, index: number, arrayPath: Path) => string;
 
@@ -24,15 +24,13 @@ function jsonSameType(
   return typea;
 }
 
-export function trimergeArrayCreator(
-  getArrayItemKey: ArrayKeyFn,
-): MergeFn<any> {
+export function trimergeArrayCreator(getArrayItemKey: ArrayKeyFn): MergeFn {
   return (
-    orig: JSONValue[],
-    left: JSONValue[],
-    right: JSONValue[],
+    orig: any,
+    left: any,
+    right: any,
     path: Path,
-    mergeFn: AnyMerge,
+    mergeFn: MergeFn,
   ): JSONValue[] | typeof CannotMerge => {
     if (jsonSameType(orig, left, right) !== 'array') {
       return CannotMerge;
@@ -53,7 +51,7 @@ function internalTrimergeArray(
   left: JSONValue[],
   right: JSONValue[],
   path: Path,
-  mergeFn: AnyMerge,
+  mergeFn: MergeFn,
   getArrayItemKey: ArrayKeyFn,
 ): JSONValue[] {
   const origMap: JSONObject = {};
@@ -147,11 +145,11 @@ function internalTrimergeArray(
 }
 
 export function trimergeJsonObject(
-  orig: JSONObject,
-  left: JSONObject,
-  right: JSONObject,
+  orig: any,
+  left: any,
+  right: any,
   path: Path,
-  mergeFn: AnyMerge,
+  mergeFn: MergeFn,
 ): JSONObject | typeof CannotMerge {
   if (jsonSameType(orig, left, right) !== 'object') {
     return CannotMerge;
@@ -176,7 +174,7 @@ function internalTrimergeJsonObject(
   leftKeys: string[],
   rightKeys: string[],
   path: Path,
-  merge: AnyMerge,
+  merge: MergeFn,
 ): JSONObject {
   const newObject: JSONObject = {};
   const keys = new Set<string>(origKeys);

--- a/src/trimerge-map.test.ts
+++ b/src/trimerge-map.test.ts
@@ -1,15 +1,15 @@
 import {
-  AnyMerge,
-  combineMergers,
   CannotMergeError,
+  combineMergers,
+  MergeFn,
   trimergeEquality,
 } from './trimerge';
 import { Path } from './path';
 import { CannotMerge } from './cannot-merge';
 import { trimergeMap } from './trimerge-map';
 
-function mockPathTrackingMerger(paths: Path[]): AnyMerge {
-  return (_orig, _left, _right, path): typeof CannotMerge => {
+function mockPathTrackingMerger(paths: Path[]): MergeFn {
+  return (_orig, _left, _right, path = []): typeof CannotMerge => {
     paths.push(path);
     return CannotMerge;
   };

--- a/src/trimerge-map.ts
+++ b/src/trimerge-map.ts
@@ -1,6 +1,6 @@
 import { Path, PathKey } from './path';
 import { CannotMerge } from './cannot-merge';
-import { AnyMerge } from './trimerge';
+import { MergeFn } from './trimerge';
 
 function* iterateKeys<K>(...maps: Map<K, any>[]): IterableIterator<K> {
   for (const map of maps) {
@@ -13,7 +13,7 @@ export function trimergeMap(
   left: any,
   right: any,
   path: Path,
-  merge: AnyMerge,
+  merge: MergeFn,
 ): Map<any, any> | typeof CannotMerge {
   if (
     !(orig instanceof Map) ||

--- a/src/trimerge-map.ts
+++ b/src/trimerge-map.ts
@@ -2,7 +2,6 @@ import { Path, PathKey } from './path';
 import { CannotMerge } from './cannot-merge';
 import { AnyMerge } from './trimerge';
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
 function* iterateKeys<K>(...maps: Map<K, any>[]): IterableIterator<K> {
   for (const map of maps) {
     yield* map.keys();

--- a/src/trimerge-router.test.ts
+++ b/src/trimerge-router.test.ts
@@ -48,7 +48,6 @@ describe('routeMergers() can build', () => {
   });
 });
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function mergeLeft(_orig: any, left: any): any {
   return left;
 }

--- a/src/trimerge-router.ts
+++ b/src/trimerge-router.ts
@@ -44,7 +44,6 @@ export function routeMergers(...routes: Route[]): AnyMerge {
     addRouter(root, path, merger);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return (orig: any, left: any, right: any, path: Path, mergeFn: AnyMerge) => {
     let node: RouteNode = root;
     for (let i = 0; i < path.length; i++) {

--- a/src/trimerge-router.ts
+++ b/src/trimerge-router.ts
@@ -1,4 +1,4 @@
-import { AnyMerge } from './trimerge';
+import { MergeFn } from './trimerge';
 import { Path } from './path';
 import { CannotMerge } from './cannot-merge';
 
@@ -7,22 +7,18 @@ export const RouteWildCard = new RouteWildCardClass();
 export type RoutePathKey = string | number | typeof RouteWildCard;
 export type RoutePath = RoutePathKey[];
 
-type Route = [RoutePath, AnyMerge];
-export function routeMergers(...routes: Route[]): AnyMerge {
+type Route = [RoutePath, MergeFn];
+export function routeMergers(...routes: Route[]): MergeFn {
   interface RouteNode {
     keyMap: RouteMap;
-    merger?: AnyMerge;
+    merger?: MergeFn;
   }
   type RouteMap = Map<RoutePathKey, RouteNode>;
   const root: RouteNode = {
     keyMap: new Map(),
   };
 
-  function addRouter(
-    node: RouteNode,
-    currentPath: RoutePath,
-    merger: AnyMerge,
-  ) {
+  function addRouter(node: RouteNode, currentPath: RoutePath, merger: MergeFn) {
     if (currentPath.length === 0) {
       if (node.merger) {
         throw new Error('duplicate route');
@@ -44,7 +40,7 @@ export function routeMergers(...routes: Route[]): AnyMerge {
     addRouter(root, path, merger);
   }
 
-  return (orig: any, left: any, right: any, path: Path, mergeFn: AnyMerge) => {
+  return (orig: any, left: any, right: any, path: Path, mergeFn: MergeFn) => {
     let node: RouteNode = root;
     for (let i = 0; i < path.length; i++) {
       const childNode =

--- a/src/trimerge-string.ts
+++ b/src/trimerge-string.ts
@@ -1,7 +1,6 @@
 import { CannotMerge } from './cannot-merge';
 import { diff3MergeStrings } from './diff3-string';
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
 export function trimergeString(
   orig: any = '',
   left: any = '',

--- a/src/trimerge.ts
+++ b/src/trimerge.ts
@@ -1,7 +1,6 @@
 import { Path } from './path';
 import { CannotMerge } from './cannot-merge';
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
 export type MergeFn<T> = (
   orig: T,
   left: T,

--- a/src/type.ts
+++ b/src/type.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function type(object: any): typeof object | 'array' | 'null' {
   const t = typeof object;
   if (t !== 'object') {


### PR DESCRIPTION
- remove no-explicit-any eslint rule
- combine AnyMerge and MergeFn
- rename index.mjs -> index.esm.js