### PR TITLE
add allowOrderConflicts option to diff3Keys, trimergeArrayCreator, and trimergeMap

### DIFF
--- a/src/diff3-keys.test.ts
+++ b/src/diff3-keys.test.ts
@@ -1,0 +1,64 @@
+import { diff3Keys } from './diff3-keys';
+
+describe('diff3Keys', () => {
+  it('does nothing for no keys', () => {
+    const callback = jest.fn();
+    diff3Keys([], [], [], callback);
+    expect(callback.mock.calls).toEqual([]);
+  });
+  it('merges added keys', () => {
+    const callback = jest.fn();
+    diff3Keys([], ['a'], ['b'], callback);
+    expect(callback.mock.calls).toEqual([['a'], ['b']]);
+  });
+  it('merges removed keys', () => {
+    const callback = jest.fn();
+    diff3Keys(['a', 'b', 'c'], ['a', 'b'], ['b', 'c'], callback);
+    expect(callback.mock.calls).toEqual([['b']]);
+  });
+  it('merges added and removed keys', () => {
+    const callback = jest.fn();
+    diff3Keys(['a', 'b', 'c'], ['a', 'b'], ['a', 'b', 'c', 'd'], callback);
+    expect(callback.mock.calls).toEqual([['a'], ['b'], ['d']]);
+  });
+  it('merges moved keys', () => {
+    const callback = jest.fn();
+    diff3Keys(['a', 'b', 'c'], ['c', 'a', 'b'], ['b', 'a', 'c'], callback);
+    expect(callback.mock.calls).toEqual([['c'], ['b'], ['a']]);
+  });
+  it('handles conflicting move when allowed', () => {
+    const callback = jest.fn();
+    diff3Keys(
+      ['a', 'b', 'c', 'd'],
+      ['c', 'a', 'b', 'd'],
+      ['a', 'b', 'd', 'c'],
+      callback,
+      true,
+    );
+    expect(callback.mock.calls).toEqual([['c'], ['a'], ['b'], ['d']]);
+  });
+  it('handles conflicting move when allowed 2', () => {
+    const callback = jest.fn();
+    diff3Keys(
+      ['a', 'b', 'c', 'd'],
+      ['a', 'b', 'd', 'c'],
+      ['c', 'a', 'b', 'd'],
+      callback,
+      true,
+    );
+    expect(callback.mock.calls).toEqual([['c'], ['a'], ['b'], ['d']]);
+  });
+
+  it('throws on conflicting move', () => {
+    const callback = jest.fn();
+    expect(() =>
+      diff3Keys(
+        ['a', 'b', 'c', 'd'],
+        ['a', 'b', 'd', 'c'],
+        ['c', 'a', 'b', 'd'],
+        callback,
+      ),
+    ).toThrow('order conflict');
+    expect(callback.mock.calls).toEqual([['c'], ['a'], ['b'], ['d']]);
+  });
+});

--- a/src/trimerge-json.test.ts
+++ b/src/trimerge-json.test.ts
@@ -189,6 +189,10 @@ describe('arrays', () => {
     trimergeEquality,
     trimergeArrayCreator((item) => String(item)),
   );
+  const basicArrayMergeAllowOrderConflicts = combineMergers(
+    trimergeEquality,
+    trimergeArrayCreator((item) => String(item), true),
+  );
   const idArrayMerge = combineMergers(
     trimergeJsonDeepEqual,
     trimergeArrayCreator((item: any) => String(item.id)),
@@ -255,6 +259,25 @@ describe('arrays', () => {
     const state2 = [1, 5, 2, 4, 6];
     const state3 = [2, 3, 4, 1, 5, 6];
     expect(basicArrayMerge(state1, state2, state3)).toEqual([5, 2, 4, 1, 6]);
+  });
+  it('throws on conflicting array move', () => {
+    const state1 = [1, 2, 3, 4];
+    const state2 = [3, 1, 2, 4];
+    const state3 = [1, 2, 4, 3];
+    expect(() => basicArrayMerge(state1, state2, state3)).toThrow(
+      'order conflict',
+    );
+  });
+  it('handles conflicting array move when allowed', () => {
+    const state1 = [1, 2, 3, 4];
+    const state2 = [3, 1, 2, 4];
+    const state3 = [1, 2, 4, 3];
+    expect(basicArrayMergeAllowOrderConflicts(state1, state2, state3)).toEqual([
+      3,
+      1,
+      2,
+      4,
+    ]);
   });
   it('handles array removal', () => {
     const state1 = [1, 2, 3];

--- a/src/trimerge-json.ts
+++ b/src/trimerge-json.ts
@@ -24,7 +24,10 @@ function jsonSameType(
   return typea;
 }
 
-export function trimergeArrayCreator(getArrayItemKey: ArrayKeyFn): MergeFn {
+export function trimergeArrayCreator(
+  getArrayItemKey: ArrayKeyFn,
+  allowOrderConflicts: boolean = false,
+): MergeFn {
   return (
     orig: any,
     left: any,
@@ -42,6 +45,7 @@ export function trimergeArrayCreator(getArrayItemKey: ArrayKeyFn): MergeFn {
       path,
       mergeFn,
       getArrayItemKey,
+      allowOrderConflicts,
     );
   };
 }
@@ -53,6 +57,7 @@ function internalTrimergeArray(
   path: Path,
   mergeFn: MergeFn,
   getArrayItemKey: ArrayKeyFn,
+  allowOrderConflicts: boolean,
 ): JSONValue[] {
   const origMap: JSONObject = {};
   const leftMap: JSONObject = {};
@@ -94,9 +99,15 @@ function internalTrimergeArray(
   );
 
   const result: JSONValue[] = [];
-  diff3Keys(leftKeys, origKeys, rightKeys, (key) => {
-    result.push(obj[key]);
-  });
+  diff3Keys(
+    origKeys,
+    leftKeys,
+    rightKeys,
+    (key) => {
+      result.push(obj[key]);
+    },
+    allowOrderConflicts,
+  );
   return result;
 }
 

--- a/src/trimerge-map.ts
+++ b/src/trimerge-map.ts
@@ -46,6 +46,7 @@ export function trimergeMap(
   right: any,
   path: Path,
   merge: MergeFn,
+  allowOrderConflicts: boolean = false,
 ): Map<any, any> | typeof CannotMerge {
   if (
     !(orig instanceof Map) ||
@@ -56,8 +57,8 @@ export function trimergeMap(
   }
   const newMap = new Map<any, any>();
   diff3Keys(
-    Array.from(left.keys()),
     Array.from(orig.keys()),
+    Array.from(left.keys()),
     Array.from(right.keys()),
     (key) => {
       newMap.set(
@@ -71,6 +72,7 @@ export function trimergeMap(
         ),
       );
     },
+    allowOrderConflicts,
   );
   return newMap;
 }


### PR DESCRIPTION
Previously, if there was an order conflict in diff3Keys or trimergeArrayCreator it would yield/add the entry twice. With trimergeMap it would add and trimerge the entry twice, but being a map

- Now order conflicts will throw an error
- A new `allowOrderConflicts` parameter lets you avoid the duplicate (by skipping any duplicate keys)
- Also changed the parameter order of diff3Keys to match the other functions (base, left, right)