### PR TITLE
Use fast-diff for string diffing in diffIndices

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,9 +40,7 @@
     "url": "https://github.com/marcello3d/trimerge/issues"
   },
   "homepage": "https://github.com/marcello3d/trimerge#readme",
-  "dependencies": {
-    "fast-diff": "^1.2.0"
-  },
+  "dependencies": {},
   "files": [
     "dist/**/*",
     "src/**/*"
@@ -55,6 +53,7 @@
     "codecov": "^3.5.0",
     "eslint": "^6.0.1",
     "eslint-config-prettier": "^6.0.0",
+    "fast-diff": "^1.2.0",
     "husky": "^3.0.0",
     "jest": "^24.8.0",
     "prettier": "1.18.2",

--- a/package.json
+++ b/package.json
@@ -40,12 +40,15 @@
     "url": "https://github.com/marcello3d/trimerge/issues"
   },
   "homepage": "https://github.com/marcello3d/trimerge#readme",
-  "dependencies": {},
+  "dependencies": {
+    "fast-diff": "^1.2.0"
+  },
   "files": [
     "dist/**/*",
     "src/**/*"
   ],
   "devDependencies": {
+    "@types/fast-diff": "^1.2.0",
     "@types/jest": "24.0.15",
     "@typescript-eslint/eslint-plugin": "^1.12.0",
     "@typescript-eslint/parser": "^1.12.0",

--- a/src/__snapshots__/node-diff3.test.ts.snap
+++ b/src/__snapshots__/node-diff3.test.ts.snap
@@ -1,0 +1,106 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`diffIndicesString is performant for large strings with scattered changes 1`] = `
+Array [
+  Object {
+    "a": Object {
+      "length": 0,
+      "location": 10000,
+    },
+    "b": Object {
+      "length": 10,
+      "location": 10000,
+    },
+  },
+  Object {
+    "a": Object {
+      "length": 0,
+      "location": 20000,
+    },
+    "b": Object {
+      "length": 10,
+      "location": 20010,
+    },
+  },
+  Object {
+    "a": Object {
+      "length": 0,
+      "location": 25000,
+    },
+    "b": Object {
+      "length": 10,
+      "location": 25020,
+    },
+  },
+  Object {
+    "a": Object {
+      "length": 0,
+      "location": 50000,
+    },
+    "b": Object {
+      "length": 10,
+      "location": 50030,
+    },
+  },
+  Object {
+    "a": Object {
+      "length": 0,
+      "location": 75000,
+    },
+    "b": Object {
+      "length": 10,
+      "location": 75040,
+    },
+  },
+  Object {
+    "a": Object {
+      "length": 938,
+      "location": 100000,
+    },
+    "b": Object {
+      "length": 0,
+      "location": 100050,
+    },
+  },
+  Object {
+    "a": Object {
+      "length": 0,
+      "location": 120928,
+    },
+    "b": Object {
+      "length": 106,
+      "location": 120040,
+    },
+  },
+  Object {
+    "a": Object {
+      "length": 0,
+      "location": 121010,
+    },
+    "b": Object {
+      "length": 802,
+      "location": 120228,
+    },
+  },
+  Object {
+    "a": Object {
+      "length": 10,
+      "location": 150000,
+    },
+    "b": Object {
+      "length": 0,
+      "location": 150020,
+    },
+  },
+  Object {
+    "a": Object {
+      "length": 10,
+      "location": 190000,
+    },
+    "b": Object {
+      "length": 0,
+      "location": 190010,
+    },
+  },
+]
+`;

--- a/src/node-diff3.test.ts
+++ b/src/node-diff3.test.ts
@@ -1,4 +1,11 @@
-import { diff3MergeIndices, diffIndices, LCS, makeRange } from './node-diff3';
+import {
+  diff3MergeIndices,
+  diffIndices,
+  diffIndicesLCS,
+  diffIndicesString,
+  LCS,
+  makeRange,
+} from './node-diff3';
 
 describe('diff3MergeIndices', () => {
   it('works with one-sided change', () => {
@@ -108,49 +115,52 @@ describe('diff3MergeIndices', () => {
   });
 });
 
-describe('diffIndices', () => {
-  it('zero to something', () => {
-    expect(diffIndices('', 'hello')).toEqual([
-      { a: makeRange(0, 0), b: makeRange(0, 5) },
-    ]);
-  });
-  it('add in front', () => {
-    expect(diffIndices('word.', 'hello. word.')).toEqual([
-      { a: makeRange(0, 0), b: makeRange(0, 7) },
-    ]);
-  });
-  it('add in back', () => {
-    expect(diffIndices('word.', 'word. bye.')).toEqual([
-      { a: makeRange(5, 0), b: makeRange(5, 5) },
-    ]);
-  });
-  it('replace all', () => {
-    expect(diffIndices('foo', 'bar')).toEqual([
-      { a: makeRange(0, 3), b: makeRange(0, 3) },
-    ]);
-  });
-  it('replace middle', () => {
-    expect(diffIndices('one two three', 'one four three')).toEqual([
-      { a: makeRange(4, 2), b: makeRange(4, 1) },
-      { a: makeRange(7, 0), b: makeRange(6, 2) },
-    ]);
-  });
-  it('delete front', () => {
-    expect(diffIndices('one two three', 'two three')).toEqual([
-      { a: makeRange(0, 4), b: makeRange(0, 0) },
-    ]);
-  });
-  it('delete back', () => {
-    expect(diffIndices('one two three', 'one two')).toEqual([
-      { a: makeRange(7, 6), b: makeRange(7, 0) },
-    ]);
-  });
-  it('delete middle', () => {
-    expect(diffIndices('one two three', 'one three')).toEqual([
-      { a: makeRange(5, 4), b: makeRange(5, 0) },
-    ]);
-  });
-});
+describe.each([diffIndices, diffIndicesLCS, diffIndicesString])(
+  'string diffIndices %p',
+  (diffIndices) => {
+    it('zero to something', () => {
+      expect(diffIndices('', 'hello')).toEqual([
+        { a: makeRange(0, 0), b: makeRange(0, 5) },
+      ]);
+    });
+    it('add in front', () => {
+      expect(diffIndices('word.', 'hello. word.')).toEqual([
+        { a: makeRange(0, 0), b: makeRange(0, 7) },
+      ]);
+    });
+    it('add in back', () => {
+      expect(diffIndices('word.', 'word. bye.')).toEqual([
+        { a: makeRange(5, 0), b: makeRange(5, 5) },
+      ]);
+    });
+    it('replace all', () => {
+      expect(diffIndices('foo', 'bar')).toEqual([
+        { a: makeRange(0, 3), b: makeRange(0, 3) },
+      ]);
+    });
+    it('replace middle', () => {
+      expect(diffIndices('one two three', 'one four three')).toEqual([
+        { a: makeRange(4, 2), b: makeRange(4, 1) },
+        { a: makeRange(7, 0), b: makeRange(6, 2) },
+      ]);
+    });
+    it('delete front', () => {
+      expect(diffIndices('one two three', 'two three')).toEqual([
+        { a: makeRange(0, 4), b: makeRange(0, 0) },
+      ]);
+    });
+    it('delete back', () => {
+      expect(diffIndices('one two three', 'one two')).toEqual([
+        { a: makeRange(7, 6), b: makeRange(7, 0) },
+      ]);
+    });
+    it('delete middle', () => {
+      expect(diffIndices('one two three', 'one three')).toEqual([
+        { a: makeRange(5, 4), b: makeRange(5, 0) },
+      ]);
+    });
+  },
+);
 
 describe('LCS', () => {
   it('zero to something', () => {

--- a/src/node-diff3.test.ts
+++ b/src/node-diff3.test.ts
@@ -175,33 +175,27 @@ describe('diffIndicesString', () => {
   }
   it('is performant for equal large string', () => {
     const a = makeString(200_000);
-    const now = Date.now();
     expect(diffIndicesString(a, a)).toEqual([]);
-    expect(Date.now() - now).toBeLessThan(10);
   });
   it('is performant for large strings with head diff', () => {
     const a = makeString(200_000);
     const b = `***${a}`;
-    const now = Date.now();
     expect(diffIndicesString(a, b)).toEqual([
       {
         a: makeRange(0, 0),
         b: makeRange(0, 3),
       },
     ]);
-    expect(Date.now() - now).toBeLessThan(10);
   });
   it('is performant for large strings with tail diff', () => {
     const a = makeString(200_000);
     const b = `${a}***`;
-    const now = Date.now();
     expect(diffIndicesString(a, b)).toEqual([
       {
         a: makeRange(200_000, 0),
         b: makeRange(200_000, 3),
       },
     ]);
-    expect(Date.now() - now).toBeLessThan(10);
   });
   it('is performant for large strings with scattered changes', () => {
     const a = makeString(200_000);
@@ -215,11 +209,7 @@ describe('diffIndicesString', () => {
     for (let i = addLocs.length - 1; i >= 0; i--) {
       b = `${b.slice(0, addLocs[i])}${'*'.repeat(delta)}${b.slice(addLocs[i])}`;
     }
-
-    const now = Date.now();
-    const res = diffIndicesString(a, b);
-    expect(Date.now() - now).toBeLessThan(500);
-    expect(res).toMatchSnapshot();
+    expect(diffIndicesString(a, b)).toMatchSnapshot();
   });
   it('is performant for large strings with many changes', () => {
     const a = makeString(200_000);
@@ -227,10 +217,7 @@ describe('diffIndicesString', () => {
     for (let i = 0; i < 200_000; i += 100) {
       b = `${b.slice(0, i)}*${b.slice(i + 1)}`;
     }
-
-    const now = Date.now();
-    diffIndicesString(a, b);
-    expect(Date.now() - now).toBeLessThan(500);
+    expect(diffIndicesString(a, b)).toBeDefined();
   });
 });
 

--- a/src/node-diff3.ts
+++ b/src/node-diff3.ts
@@ -6,6 +6,8 @@
 // - Generalized for any array type
 // -
 
+import fastDiff from 'fast-diff';
+
 interface Range {
   location: number;
   length: number;
@@ -138,14 +140,63 @@ interface DiffIndicesResult {
   a: Range;
   b: Range;
 }
+
+export function diffIndicesString(a: string, b: string): DiffIndicesResult[] {
+  const result: DiffIndicesResult[] = [];
+  const diffResult = fastDiff(a as string, b as string);
+
+  let aIndex = 0;
+  let bIndex = 0;
+
+  let lastA = 0;
+  let lastB = 0;
+
+  function flush() {
+    if (aIndex > lastA || bIndex > lastB) {
+      result.push({
+        a: makeRange(lastA, aIndex - lastA),
+        b: makeRange(lastB, bIndex - lastB),
+      });
+    }
+  }
+
+  for (const [type, str] of diffResult) {
+    switch (type) {
+      case fastDiff.EQUAL: {
+        flush();
+        aIndex += str.length;
+        bIndex += str.length;
+        lastA = aIndex;
+        lastB = bIndex;
+        break;
+      }
+      case fastDiff.INSERT: {
+        bIndex += str.length;
+        break;
+      }
+      case fastDiff.DELETE: {
+        aIndex += str.length;
+        break;
+      }
+    }
+  }
+  flush();
+
+  return result;
+}
+
 // We apply the LCS to give a simple representation of the
 // offsets and lengths of mismatched chunks in the input
 // files. This is used by diff3MergeIndices below.
-export function diffIndices<T>(
+export function diffIndicesLCS<T>(
   a: ArrayLike<T>,
   b: ArrayLike<T>,
 ): DiffIndicesResult[] {
   const result: DiffIndicesResult[] = [];
+
+  if (typeof a === 'string' && typeof b === 'string') {
+  }
+
   let tail1 = a.length;
   let tail2 = b.length;
 
@@ -169,6 +220,16 @@ export function diffIndices<T>(
 
   result.reverse();
   return result;
+}
+
+export function diffIndices<T>(
+  a: ArrayLike<T>,
+  b: ArrayLike<T>,
+): DiffIndicesResult[] {
+  if (typeof a === 'string' && typeof b === 'string') {
+    return diffIndicesString(a, b);
+  }
+  return diffIndicesLCS(a, b);
 }
 
 // Given three files, A, O, and B, where both A and B are

--- a/src/node-diff3.ts
+++ b/src/node-diff3.ts
@@ -142,14 +142,15 @@ interface DiffIndicesResult {
 }
 
 export function diffIndicesString(a: string, b: string): DiffIndicesResult[] {
-  const result: DiffIndicesResult[] = [];
-  const diffResult = fastDiff(a as string, b as string);
+  const diffResult = fastDiff(a, b);
 
   let aIndex = 0;
   let bIndex = 0;
 
   let lastA = 0;
   let lastB = 0;
+
+  const result: DiffIndicesResult[] = [];
 
   function flush() {
     if (aIndex > lastA || bIndex > lastB) {

--- a/src/node-diff3.ts
+++ b/src/node-diff3.ts
@@ -194,9 +194,6 @@ export function diffIndicesLCS<T>(
 ): DiffIndicesResult[] {
   const result: DiffIndicesResult[] = [];
 
-  if (typeof a === 'string' && typeof b === 'string') {
-  }
-
   let tail1 = a.length;
   let tail2 = b.length;
 


### PR DESCRIPTION
`fast-diff` is much more efficient than computing the longest common subsequence (LCS) of two strings.